### PR TITLE
AutoConfigureStubRunner + fixed prop

### DIFF
--- a/reservation-client/src/test/java/com/example/reservationclient/ReservationClientApplicationTests.java
+++ b/reservation-client/src/test/java/com/example/reservationclient/ReservationClientApplicationTests.java
@@ -1,29 +1,23 @@
 package com.example.reservationclient;
 
+import java.util.Collection;
+
 import org.assertj.core.api.BDDAssertions;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.contract.stubrunner.junit.StubRunnerRule;
 import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.Collection;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@AutoConfigureStubRunner(ids = "com.example:reservation-service:+:stubs:8000",
+        workOffline = true)
 public class ReservationClientApplicationTests {
 
     @Autowired
     private ReservationReader reservationReader;
-
-    @Rule
-    public StubRunnerRule stubRunnerRule = new StubRunnerRule()
-            .downloadStub("com.example", "reservation-service")
-            .workOffline(true)
-            .withPort(8000);
 
     @Test
     public void should_load_all_reservations() {

--- a/reservation-service/src/test/resources/application.properties
+++ b/reservation-service/src/test/resources/application.properties
@@ -1,1 +1,1 @@
-eureka.client.enabled=falsemv 
+eureka.client.enabled=false


### PR DESCRIPTION
The `StubRunnerRule` won't work cause it's Spring agnostic. `Feign` machinery is tightly coupled to Spring. That's why you need to use the `@AutoConfigureStubRunner` Spring autoconfiguration